### PR TITLE
Import test results always in the same order

### DIFF
--- a/src/main/java/app/getxray/maven/plugin/xray/ImportResultsMojo.java
+++ b/src/main/java/app/getxray/maven/plugin/xray/ImportResultsMojo.java
@@ -132,6 +132,7 @@ public class ImportResultsMojo extends AbstractMojo {
             scanner.setIncludes(new String[]{"*.xml"});
             scanner.setBasedir(reportFile);
             scanner.setCaseSensitive(false);
+            scanner.setFilenameComparator(String::compareTo);
             scanner.scan();
             reportFiles = scanner.getIncludedFiles();
             for (int i = 0; i < reportFiles.length; i++) {
@@ -144,6 +145,7 @@ public class ImportResultsMojo extends AbstractMojo {
             scanner.setIncludes(new String[]{reportFile});
             scanner.setBasedir(".");
             scanner.setCaseSensitive(false);
+            scanner.setFilenameComparator(String::compareTo);
             scanner.scan();
             reportFiles = scanner.getIncludedFiles();
             for (int i = 0; i < reportFiles.length; i++) {


### PR DESCRIPTION
Hello,

In the company where I work we run the tests few times with Surefire's [rerunFailingTestsCount](https://maven.apache.org/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html) config variable.
In this case, `xray-junit-extensions` creates multiple *.xml report files with date, for example:

```
xray-junit-2024_04_23-10_01_02_140.xml
xray-junit-2024_04_23-10_01_17_134.xml
xray-junit-2024_04_23-10_02_37_633.xml
xray-junit-2024_04_23-10_04_10_105.xml
xray-junit-2024_04_23-10_05_29_264.xml
xray-junit-2024_04_23-10_06_19_963.xml
xray-junit-2024_04_23-10_06_55_141.xml
```

The goal is to send test results to Jira in the same order in which they were run - from oldest to newest.
In this PR I added a comparator that should solve this problem.